### PR TITLE
Upgrade maven-artifact to latest patch to remove transitive CVE for #62

### DIFF
--- a/mongock-core/mongock-runner/mongock-runner-core/pom.xml
+++ b/mongock-core/mongock-runner/mongock-runner-core/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
-      <version>3.6.1</version>
+      <version>3.9.11</version>
     </dependency>
     
     <dependency>


### PR DESCRIPTION
## Issue reference

https://github.com/flamingock/mongock/issues/62

## Documentation PR reference

It did not appear that we list dependency info in the documentation today, so no PR made.

## Description and context

Needed to upgrade this standard dependency to resolve transitive dependency on old apache commons-lang3 subject to https://www.cve.org/CVERecord?id=CVE-2025-48924

## Benefits

Now using latest 3.x version of maven library.

## Possible Drawbacks

Should not be any noticeable drawbacks.

## Checklist 
- [x] Unit tests provided
- [x] Integration tests provided 
- [x] Documentation updated in [documentation project](https://github.com/mongock/mongock-docs)
- [x] Updated example in [example projects](https://github.com/mongock/mongock-examples)

